### PR TITLE
fix jitter when using nested compound nodes with avoidOverlap

### DIFF
--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -398,7 +398,9 @@ SOFTWARE.
 
           padding: Math.max( pleft, pright, ptop, pbottom ),
 
-          leaves: node.descendants().stdFilter(function( child ){
+          // leaves should only contain direct descendants (children),
+          // not the leaves of nested compound nodes or any nodes that are compounds themselves
+          leaves: node.children().stdFilter(function( child ){
             return !child.isParent();
           }).map(function( child ){
             return child[0].scratch().cola.index;
@@ -409,7 +411,7 @@ SOFTWARE.
 
         return node;
       }).map(function( node ){ // add subgroups
-        node.scratch().cola.groups = node.descendants().stdFilter(function( child ){
+        node.scratch().cola.groups = node.children().stdFilter(function( child ){
           return child.isParent();
         }).map(function( child ){
           return child.scratch().cola.index;


### PR DESCRIPTION
Fixes https://github.com/tgdwyer/WebCola/issues/177.
this PR fixes issues using `avoidOverlap` with nested compound nodes, leading to a layout like this:

![jittery output](https://cloud.githubusercontent.com/assets/1409100/16187646/cd180be2-36d1-11e6-9eba-964397316a14.gif)

There is also a jsbin which uses cytoscape-colas output directly with cola: http://jsbin.com/cecujexico/1/edit?html,js,output

This happened because the scratch data structure that got passed to webcola did also contain the deeply nested leaves. This lead to an illegal state when calculating overlaps, because a node was nested within multiple compound nodes, in extreme cases within all.

Here is the rendering after the fix:

![cytoscape-cola-fix](https://cloud.githubusercontent.com/assets/1409100/18054527/8d01cbdc-6e04-11e6-8fdc-7befd68cca84.gif)

Notice that this rendering uses the following settings: 
```js

    avoidOverlap: true,
    edgeLength: 250, // should be at least two times the diagonal of a block, blocks are 100x60, therefore around 2*116
    unconstrIter: 100, // unconstrained initial layout iterations
    userConstIter: 0, // initial layout iterations with user-specified constraints - we don't have any user constraints
    allConstIter: 10 // initial layout iterations with all constraints including non-overlap
```


Thanks to @uruuru for his help.