### PR TITLE
Do not assume all nodes were given to the layout

### DIFF
--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -131,12 +131,8 @@ ColaLayout.prototype.run = function () {
   var edges = eles.edges();
   var ready = false;
 
-  var isPresent = function isPresent(node) {
-    return this.getElementById(node.id()).length;
-  };
-
   var parentNodes = nodes.stdFilter(function (node) {
-    return node.children().some(isPresent.bind(nodes));
+    return node.children().some(nodes.contains.bind(nodes));
   });
   var nonparentNodes = nodes.subtract(parentNodes);
 
@@ -177,7 +173,7 @@ ColaLayout.prototype.run = function () {
       var scratch = node.scratch().cola;
       var retPos = void 0;
 
-      if (!node.grabbed() && isPresent.call(nonparentNodes, node)) {
+      if (!node.grabbed() && nonparentNodes.contains(node)) {
         retPos = {
           x: bb.x1 + scratch.x,
           y: bb.y1 + scratch.y
@@ -517,7 +513,7 @@ ColaLayout.prototype.run = function () {
 
   // add the edges to cola
   adaptor.links(edges.stdFilter(function (edge) {
-    return isPresent.call(nonparentNodes, edge.source()) && isPresent.call(nonparentNodes, edge.target());
+    return nonparentNodes.contains(edge.source()) && nonparentNodes.contains(edge.target());
   }).map(function (edge) {
     var c = edge.scratch().cola = {
       source: edge.source()[0].scratch().cola.index,

--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -132,7 +132,7 @@ ColaLayout.prototype.run = function () {
   var ready = false;
 
   var isPresent = function isPresent(node) {
-    return this.getElementById(node.id());
+    return this.getElementById(node.id()).length;
   };
 
   var parentNodes = nodes.stdFilter(function (node) {

--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -131,6 +131,15 @@ ColaLayout.prototype.run = function () {
   var edges = eles.edges();
   var ready = false;
 
+  var isPresent = function isPresent(node) {
+    return this.getElementById(node.id());
+  };
+
+  var parentNodes = nodes.stdFilter(function (node) {
+    return node.children().some(isPresent.bind(nodes));
+  });
+  var nonparentNodes = nodes.subtract(parentNodes);
+
   var bb = options.boundingBox || { x1: 0, y1: 0, w: cy.width(), h: cy.height() };
   if (bb.x2 === undefined) {
     bb.x2 = bb.x1 + bb.w;
@@ -168,7 +177,7 @@ ColaLayout.prototype.run = function () {
       var scratch = node.scratch().cola;
       var retPos = void 0;
 
-      if (!node.grabbed() && !node.isParent()) {
+      if (!node.grabbed() && isPresent.call(nonparentNodes, node)) {
         retPos = {
           x: bb.x1 + scratch.x,
           y: bb.y1 + scratch.y
@@ -356,10 +365,6 @@ ColaLayout.prototype.run = function () {
     }
   });
 
-  var nonparentNodes = nodes.stdFilter(function (node) {
-    return !node.isParent();
-  });
-
   // add nodes to cola
   adaptor.nodes(nonparentNodes.map(function (node, i) {
     var padding = getOptVal(options.nodeSpacing, node);
@@ -453,9 +458,7 @@ ColaLayout.prototype.run = function () {
   }
 
   // add compound nodes to cola
-  adaptor.groups(nodes.stdFilter(function (node) {
-    return node.isParent();
-  }).map(function (node, i) {
+  adaptor.groups(parentNodes.map(function (node, i) {
     // add basic group incl leaf nodes
     var optPadding = getOptVal(options.nodeSpacing, node);
     var getPadding = function getPadding(d) {
@@ -474,9 +477,7 @@ ColaLayout.prototype.run = function () {
 
       // leaves should only contain direct descendants (children),
       // not the leaves of nested compound nodes or any nodes that are compounds themselves
-      leaves: node.children().stdFilter(function (child) {
-        return !child.isParent();
-      }).map(function (child) {
+      leaves: node.children().intersection(nonparentNodes).map(function (child) {
         return child[0].scratch().cola.index;
       }),
 
@@ -486,9 +487,7 @@ ColaLayout.prototype.run = function () {
     return node;
   }).map(function (node) {
     // add subgroups
-    node.scratch().cola.groups = node.children().stdFilter(function (child) {
-      return child.isParent();
-    }).map(function (child) {
+    node.scratch().cola.groups = node.children().intersection(parentNodes).map(function (child) {
       return child.scratch().cola.index;
     });
 
@@ -518,7 +517,7 @@ ColaLayout.prototype.run = function () {
 
   // add the edges to cola
   adaptor.links(edges.stdFilter(function (edge) {
-    return !edge.source().isParent() && !edge.target().isParent();
+    return isPresent.call(nonparentNodes, edge.source()) && isPresent.call(nonparentNodes, edge.target());
   }).map(function (edge) {
     var c = edge.scratch().cola = {
       source: edge.source()[0].scratch().cola.index,

--- a/src/cola.js
+++ b/src/cola.js
@@ -36,12 +36,8 @@ ColaLayout.prototype.run = function(){
   let edges = eles.edges();
   let ready = false;
 
-  let isPresent = function(node) {
-    return this.getElementById(node.id()).length;
-  };
-
   let parentNodes = nodes.stdFilter(function(node) {
-    return node.children().some(isPresent.bind(nodes));
+    return node.children().some(nodes.contains.bind(nodes));
   });
   let nonparentNodes = nodes.subtract(parentNodes);
 
@@ -74,7 +70,7 @@ ColaLayout.prototype.run = function(){
       let scratch = node.scratch().cola;
       let retPos;
 
-      if( !node.grabbed() && isPresent.call(nonparentNodes, node) ){
+      if( !node.grabbed() && nonparentNodes.contains(node) ){
         retPos = {
           x: bb.x1 + scratch.x,
           y: bb.y1 + scratch.y
@@ -406,7 +402,7 @@ ColaLayout.prototype.run = function(){
 
   // add the edges to cola
   adaptor.links( edges.stdFilter(function( edge ){
-    return isPresent.call(nonparentNodes, edge.source()) && isPresent.call(nonparentNodes, edge.target());
+    return nonparentNodes.contains(edge.source()) && nonparentNodes.contains(edge.target());
   }).map(function( edge ){
     let c = edge.scratch().cola = {
       source: edge.source()[0].scratch().cola.index,

--- a/src/cola.js
+++ b/src/cola.js
@@ -37,7 +37,7 @@ ColaLayout.prototype.run = function(){
   let ready = false;
 
   let isPresent = function(node) {
-    return this.getElementById(node.id());
+    return this.getElementById(node.id()).length;
   };
 
   let parentNodes = nodes.stdFilter(function(node) {


### PR DESCRIPTION
This PR is intended to fix an issue where the layout will fail if it has not been given all of the children of a compound node.