### PR TITLE
Enable multiple alignment constraints and fix fixed node constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cytoscape-cola
 
 ## Description
 
-The Cola.js physics simulation layout for Cytoscape.js ([demo](https://cytoscape.github.io/cytoscape.js-cola), [non-animated demo](https://cytoscape.github.io/cytoscape.js-cola/demo-non-animated.html), [compound demo](https://cytoscape.github.io/cytoscape.js-cola/demo-compound.html))
+The Cola.js physics simulation layout for Cytoscape.js ([demo](https://cytoscape.github.io/cytoscape.js-cola), [non-animated demo](https://cytoscape.github.io/cytoscape.js-cola/demo-non-animated.html), [compound demo](https://cytoscape.github.io/cytoscape.js-cola/demo-compound.html), [constraint demo](https://cytoscape.github.io/cytoscape.js-cola/demo-constraints.html))
 
 
 The `cola` layout uses a [force-directed](http://en.wikipedia.org/wiki/Force-directed_graph_drawing) physics simulation with several sophisticated constraints, written by [Tim Dwyer](http://www.csse.monash.edu.au/~tdwyer/).  For more information about Cola and its parameters, refer to [its documentation](http://marvl.infotech.monash.edu/webcola/).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ var defaults = {
   convergenceThreshold: 0.01, // when the alpha value (system energy) falls below this value, the layout stops
   nodeSpacing: function( node ){ return 10; }, // extra spacing around nodes
   flow: undefined, // use DAG/tree flow layout if specified, e.g. { axis: 'y', minSeparation: 30 }
-  alignment: undefined, // relative alignment constraints on nodes, e.g. {vertical: [['n1', 'n2')], ['n3', 'n4']], horizontal: [['n5', 'n6']]}
+  alignment: undefined, // relative alignment constraints on nodes, e.g. {vertical: [[{node: node1, offset: 0}, {node: node2, offset: 5}]], horizontal: [[{node: node3}, {node: node4}], [{node: node5}, {node: node6}]]}
   gapInequalities: undefined, // list of inequality constraints for the gap between the nodes, e.g. [{"axis":"y", "left":node1, "right":node2, "gap":25}]
 
   // different methods of specifying edge length

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ var defaults = {
   convergenceThreshold: 0.01, // when the alpha value (system energy) falls below this value, the layout stops
   nodeSpacing: function( node ){ return 10; }, // extra spacing around nodes
   flow: undefined, // use DAG/tree flow layout if specified, e.g. { axis: 'y', minSeparation: 30 }
-  alignment: undefined, // relative alignment constraints on nodes, e.g. function( node ){ return { x: 0, y: 1 } }
+  alignment: undefined, // relative alignment constraints on nodes, e.g. {vertical: [['n1', 'n2')], ['n3', 'n4']], horizontal: [['n5', 'n6']]}
   gapInequalities: undefined, // list of inequality constraints for the gap between the nodes, e.g. [{"axis":"y", "left":node1, "right":node2, "gap":25}]
 
   // different methods of specifying edge length

--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -375,8 +375,8 @@ ColaLayout.prototype.run = function () {
     var dimensions = node.layoutDimensions(options);
 
     var struct = node.scratch().cola = {
-      x: options.randomize || pos.x === undefined ? Math.round(Math.random() * bb.w) : pos.x,
-      y: options.randomize || pos.y === undefined ? Math.round(Math.random() * bb.h) : pos.y,
+      x: options.randomize && !node.locked() || pos.x === undefined ? Math.round(Math.random() * bb.w) : pos.x,
+      y: options.randomize && !node.locked() || pos.y === undefined ? Math.round(Math.random() * bb.h) : pos.y,
       width: dimensions.w + 2 * padding,
       height: dimensions.h + 2 * padding,
       index: i,

--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -396,13 +396,13 @@ ColaLayout.prototype.run = function () {
       var verticalAlignments = options.alignment.vertical;
       verticalAlignments.forEach(function (alignment) {
         var offsetsX = [];
-        alignment.forEach(function (nodeId) {
-          var node = cy.getElementById(nodeId);
+        alignment.forEach(function (nodeData) {
+          var node = nodeData.node;
           var scrCola = node.scratch().cola;
           var index = scrCola.index;
           offsetsX.push({
             node: index,
-            offset: 0
+            offset: nodeData.offset ? nodeData.offset : 0
           });
         });
         constraints.push({
@@ -417,13 +417,13 @@ ColaLayout.prototype.run = function () {
       var horizontalAlignments = options.alignment.horizontal;
       horizontalAlignments.forEach(function (alignment) {
         var offsetsY = [];
-        alignment.forEach(function (nodeId) {
-          var node = cy.getElementById(nodeId);
+        alignment.forEach(function (nodeData) {
+          var node = nodeData.node;
           var scrCola = node.scratch().cola;
           var index = scrCola.index;
           offsetsY.push({
             node: index,
-            offset: 0
+            offset: nodeData.offset ? nodeData.offset : 0
           });
         });
         constraints.push({

--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -392,46 +392,45 @@ ColaLayout.prototype.run = function () {
   if (options.alignment) {
     // then set alignment constraints
 
-    var offsetsX = [];
-    var offsetsY = [];
-
-    nonparentNodes.forEach(function (node) {
-      var align = getOptVal(options.alignment, node);
-      var scrCola = node.scratch().cola;
-      var index = scrCola.index;
-
-      if (!align) {
-        return;
-      }
-
-      if (align.x != null) {
-        offsetsX.push({
-          node: index,
-          offset: align.x
+    if (options.alignment.vertical) {
+      var verticalAlignments = options.alignment.vertical;
+      verticalAlignments.forEach(function (alignment) {
+        var offsetsX = [];
+        alignment.forEach(function (nodeId) {
+          var node = cy.getElementById(nodeId);
+          var scrCola = node.scratch().cola;
+          var index = scrCola.index;
+          offsetsX.push({
+            node: index,
+            offset: 0
+          });
         });
-      }
-
-      if (align.y != null) {
-        offsetsY.push({
-          node: index,
-          offset: align.y
+        constraints.push({
+          type: 'alignment',
+          axis: 'x',
+          offsets: offsetsX
         });
-      }
-    });
-
-    if (offsetsX.length > 0) {
-      constraints.push({
-        type: 'alignment',
-        axis: 'x',
-        offsets: offsetsX
       });
     }
 
-    if (offsetsY.length > 0) {
-      constraints.push({
-        type: 'alignment',
-        axis: 'y',
-        offsets: offsetsY
+    if (options.alignment.horizontal) {
+      var horizontalAlignments = options.alignment.horizontal;
+      horizontalAlignments.forEach(function (alignment) {
+        var offsetsY = [];
+        alignment.forEach(function (nodeId) {
+          var node = cy.getElementById(nodeId);
+          var scrCola = node.scratch().cola;
+          var index = scrCola.index;
+          offsetsY.push({
+            node: index,
+            offset: 0
+          });
+        });
+        constraints.push({
+          type: 'alignment',
+          axis: 'y',
+          offsets: offsetsY
+        });
       });
     }
   }

--- a/demo-constraints.html
+++ b/demo-constraints.html
@@ -1,0 +1,180 @@
+<!DOCTYPE>
+
+<html>
+
+	<head>
+		<title>cytoscape-cola.js demo</title>
+
+		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+		<script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+
+		<!-- for testing with local version of cytoscape.js -->
+		<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
+
+		<script src="https://unpkg.com/webcola/WebCola/cola.min.js"></script>
+		<script src="cytoscape-cola.js"></script>
+
+		<style>
+			body {
+				font-family: helvetica;
+				font-size: 14px;
+			}
+
+			#cy {
+				width: 100%;
+				height: 100%;
+				position: absolute;
+				left: 0;
+				top: 0;
+				z-index: 999;
+			}
+
+			h1 {
+				opacity: 0.5;
+				font-size: 1em;
+			}
+		</style>
+
+		<script>
+			document.addEventListener('DOMContentLoaded', function(){
+
+				var cy = window.cy = cytoscape({
+					container: document.getElementById('cy'),
+
+					boxSelectionEnabled: false,
+
+					layout: {
+            name: 'cola',
+            convergenceThreshold: 100, // end layout sooner, may be a bit lower quality
+            animate: false
+					},
+
+					style: [
+						{
+							selector: 'node',
+							css: {
+								'background-color': '#f92411',
+								'content': 'data(label)',
+								'width': 'data(size)',
+								'height': 'data(size)'
+							}
+						},
+
+						{
+							selector: 'edge',
+							css: {
+								'line-color': '#f92411'
+							}
+						}
+					],
+
+					elements: {
+					  nodes: [
+					    {
+					      data: {
+					        id: "1",
+					        label: "n1",
+					        size: 30
+					      }
+					    },
+					    {
+					      data: {
+					        id: "2",
+					        label: "n2",
+					        size: 50
+					      }
+					    },
+					    {
+					      data: {
+					        id: "3",
+					        label: "n3",
+					        size: 30
+					      }
+					    },
+					    {
+					      data: {
+					        id: "4",
+					        label: "n4",
+					        size: 50
+					      }
+					    },
+					    {
+					      data: {
+					        id: "5",
+					        label: "n5",
+					        size: 30
+					      }
+					    },
+					    {
+					      data: {
+					        id: "6",
+					        label: "n6",
+					        size: 50
+					      }
+					    }
+					    ],
+					    edges: [
+					    {
+					      data: {
+					        source: "1",
+					        target: "2"
+					      }
+					    },
+					    {
+					      data: {
+					        source: "1",
+					        target: "3"
+					      }
+					    },
+					    {
+					      data: {
+					        source: "3",
+					        target: "4"
+					      }
+					    },
+					    {
+					      data: {
+					        source: "3",
+					        target: "5"
+					      }
+					    },
+					    {
+					      data: {
+					        source: "5",
+					        target: "6"
+					      }
+					    }
+					  ]
+					}
+				});
+				// fix node n1 to x:100, y:100
+				cy.$id('3').position({x: 100, y:100}).lock();
+
+				cy.layout({name: 'cola', randomize: true, animate: false, padding: 100,
+					alignment: {vertical: [[{node: cy.$id('1'), offset: 0}, {node: cy.$id('2'), offset: 10}], 
+						[{node: cy.$id('3'), offset: 0}, {node: cy.$id('4'), offset: 0}], 
+						[{node: cy.$id('5'), offset: 0}, {node: cy.$id('6'), offset: -10}]],
+						horizontal: [[{node: cy.$id('1')}, {node: cy.$id('3')}, {node: cy.$id('5')}]]},
+          gapInequalities: [{"axis":"x", "left": cy.$id('1'), "right": cy.$id('3'), "gap":100, 'equality': true},
+						{"axis":"x", "left": cy.$id('3'), "right": cy.$id('5'), "gap":100, 'equality': true}]}).run();
+
+			});
+		</script>
+	</head>
+
+	<body>
+		<h1>cytoscape-cola demo</h1>
+		<p>n3 is fixed to x: 100, y: 100</p>
+		<p>n1 - n2 vertical alignment on left side</p>
+		<p>n3 - n4 vertical alignment on center</p>
+		<p>n5 - n6 vertical alignment on right side</p>
+		<p>n1 - n3 - n5 horizontal alignment</p>
+		<p>n1.x + 100 = n3.x</p>
+		<p>n3.x + 100 = n5.x</p>
+
+		<div id="cy"></div>
+
+	</body>
+
+</html>

--- a/src/cola.js
+++ b/src/cola.js
@@ -277,46 +277,47 @@ ColaLayout.prototype.run = function(){
 
   if( options.alignment ){ // then set alignment constraints
 
-    let offsetsX = [];
-    let offsetsY = [];
-
-    nonparentNodes.forEach(function( node ){
-      let align = getOptVal( options.alignment, node );
-      let scrCola = node.scratch().cola;
-      let index = scrCola.index;
-
-      if( !align ){ return; }
-
-      if( align.x != null ){
-        offsetsX.push({
-          node: index,
-          offset: align.x
+    if(options.alignment.vertical) {
+      let verticalAlignments = options.alignment.vertical;
+      verticalAlignments.forEach(function(alignment){
+        let offsetsX = [];
+        alignment.forEach(function(nodeId){
+          let node = cy.getElementById(nodeId);
+          let scrCola = node.scratch().cola;
+          let index = scrCola.index;
+          offsetsX.push({
+            node: index,
+            offset: 0
+          });
         });
-      }
-
-      if( align.y != null ){
-        offsetsY.push({
-          node: index,
-          offset: align.y
-        });
-      }
-    });
-
-    if( offsetsX.length > 0 ){
-      constraints.push({
-        type: 'alignment',
-        axis: 'x',
-        offsets: offsetsX
+        constraints.push({
+          type: 'alignment',
+          axis: 'x',
+          offsets: offsetsX
+        });        
       });
     }
 
-    if( offsetsY.length > 0 ){
-      constraints.push({
-        type: 'alignment',
-        axis: 'y',
-        offsets: offsetsY
+    if(options.alignment.horizontal) {
+      let horizontalAlignments = options.alignment.horizontal;
+      horizontalAlignments.forEach(function(alignment){
+        let offsetsY = [];
+        alignment.forEach(function(nodeId){
+          let node = cy.getElementById(nodeId);
+          let scrCola = node.scratch().cola;
+          let index = scrCola.index;
+          offsetsY.push({
+            node: index,
+            offset: 0
+          });
+        });
+        constraints.push({
+          type: 'alignment',
+          axis: 'y',
+          offsets: offsetsY
+        });        
       });
-    }
+    } 
 
   }
 

--- a/src/cola.js
+++ b/src/cola.js
@@ -281,13 +281,13 @@ ColaLayout.prototype.run = function(){
       let verticalAlignments = options.alignment.vertical;
       verticalAlignments.forEach(function(alignment){
         let offsetsX = [];
-        alignment.forEach(function(nodeId){
-          let node = cy.getElementById(nodeId);
+        alignment.forEach(function(nodeData){
+          let node = nodeData.node;
           let scrCola = node.scratch().cola;
           let index = scrCola.index;
           offsetsX.push({
             node: index,
-            offset: 0
+            offset: nodeData.offset ? nodeData.offset : 0
           });
         });
         constraints.push({
@@ -302,13 +302,13 @@ ColaLayout.prototype.run = function(){
       let horizontalAlignments = options.alignment.horizontal;
       horizontalAlignments.forEach(function(alignment){
         let offsetsY = [];
-        alignment.forEach(function(nodeId){
-          let node = cy.getElementById(nodeId);
+        alignment.forEach(function(nodeData){
+          let node = nodeData.node;
           let scrCola = node.scratch().cola;
           let index = scrCola.index;
           offsetsY.push({
             node: index,
-            offset: 0
+            offset: nodeData.offset ? nodeData.offset : 0
           });
         });
         constraints.push({

--- a/src/cola.js
+++ b/src/cola.js
@@ -261,8 +261,8 @@ ColaLayout.prototype.run = function(){
     let dimensions = node.layoutDimensions( options );
 
     let struct = node.scratch().cola = {
-      x: options.randomize || pos.x === undefined ? Math.round( Math.random() * bb.w ) : pos.x,
-      y: options.randomize || pos.y === undefined ? Math.round( Math.random() * bb.h ) : pos.y,
+      x: (options.randomize && !node.locked()) || pos.x === undefined ? Math.round( Math.random() * bb.w ) : pos.x,
+      y: (options.randomize && !node.locked()) || pos.y === undefined ? Math.round( Math.random() * bb.h ) : pos.y,
       width: dimensions.w + 2*padding,
       height: dimensions.h + 2*padding,
       index: i,


### PR DESCRIPTION
This PR aims the following contributions:

- Before, user was able to create only one alignment constraint in each direction. Now, extension allows multiple alignment constraints in each direction. User can also provide offset values for each alignment set as before. 

- Before, randomized layout was assigning a random position to a node even if that node is locked and layout was taking that random position into account. Now, randomized layout respects the locked position of the nodes.