### PR TITLE
Add centerGraph option

### DIFF
--- a/src/cola.js
+++ b/src/cola.js
@@ -464,7 +464,14 @@ ColaLayout.prototype.run = function(){
   adaptor
     .avoidOverlaps( options.avoidOverlap )
     .handleDisconnected( options.handleDisconnected )
-    .start( options.unconstrIter, options.userConstIter, options.allConstIter)
+    .start(
+      options.unconstrIter,
+      options.userConstIter,
+      options.allConstIter,
+      undefined, // gridSnapIterations = 0
+      undefined, // keepRunning = true
+      options.centerGraph
+    )
   ;
 
   if( !options.infinite ){

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -22,6 +22,8 @@ let defaults = {
   flow: undefined, // use DAG/tree flow layout if specified, e.g. { axis: 'y', minSeparation: 30 }
   alignment: undefined, // relative alignment constraints on nodes, e.g. function( node ){ return { x: 0, y: 1 } }
   gapInequalities: undefined, // list of inequality constraints for the gap between the nodes, e.g. [{"axis":"y", "left":node1, "right":node2, "gap":25}]
+  centerGraph: true, // adjusts the node positions initially to center the graph (pass false if you want to start the layout from the current position)
+
 
   // different methods of specifying edge length
   // each can be a constant numerical value or a function like `function( edge ){ return 2; }`


### PR DESCRIPTION
In order to save the users resources, I wanted to stop the layout when the user didn't interact with it. To prevent flickering, I needed a way to restart the layout without centering the nodes. I described the issue in more detail here: 

https://stackoverflow.com/questions/66370051/cytoscape-cola-layout-how-to-restart-the-layout-without-any-change-of-positions

The solution was quite simple, since the cola layout already accepts the `centerGraph` parameter. There just wasn't a way to pass it through this wrapper. 

Now the layout can be restarted like this, without the nodes changing their position:
```js
layout.stop();
layout.destroy(); // cleanup event listeners
layout = graph.layout({ name: 'cola', infinite: true, fit: false, centerGraph: false });
layout.run();
```