### PR TITLE
Mention centerGraph option in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ var defaults = {
   flow: undefined, // use DAG/tree flow layout if specified, e.g. { axis: 'y', minSeparation: 30 }
   alignment: undefined, // relative alignment constraints on nodes, e.g. {vertical: [[{node: node1, offset: 0}, {node: node2, offset: 5}]], horizontal: [[{node: node3}, {node: node4}], [{node: node5}, {node: node6}]]}
   gapInequalities: undefined, // list of inequality constraints for the gap between the nodes, e.g. [{"axis":"y", "left":node1, "right":node2, "gap":25}]
+  centerGraph: true, // adjusts the node positions initially to center the graph (pass false if you want to start the layout from the current position)
 
   // different methods of specifying edge length
   // each can be a constant numerical value or a function like `function( edge ){ return 2; }`


### PR DESCRIPTION
Davide asked me to add the `centerGraph` option that I introduced in https://github.com/cytoscape/cytoscape.js-cola/pull/65 to the Readme as well.