### PR TITLE
Improve timeout handling

### DIFF
--- a/cytoscape-cola.js
+++ b/cytoscape-cola.js
@@ -291,20 +291,27 @@ ColaLayout.prototype.run = function () {
         return ret;
       };
 
-      if (options.animate) {
-        var frame = function frame() {
-          if (multitick()) {
-            return;
-          }
+      // if not animated, run in a timeout so the
+      // options.maxSimulationTime timeout has a chance to interrupt
+      var frame = function frame() {
+        if (multitick()) {
+          return;
+        }
 
+        if (options.animate) {
           raf(frame);
-        };
-
+        } else {
+          setTimeout(function () {
+            return frame();
+          });
+        }
+      };
+      if (options.animate) {
         raf(frame);
       } else {
-        while (!inftick()) {
-          // keep going...
-        }
+        setTimeout(function () {
+          return frame();
+        });
       }
     },
 
@@ -573,10 +580,6 @@ ColaLayout.prototype.run = function () {
 
   layout.trigger({ type: 'layoutstart', layout: layout });
 
-  adaptor.avoidOverlaps(options.avoidOverlap).handleDisconnected(options.handleDisconnected).start(options.unconstrIter, options.userConstIter, options.allConstIter, undefined, // gridSnapIterations = 0
-  undefined, // keepRunning = true
-  options.centerGraph);
-
   if (!options.infinite) {
     setTimeout(function () {
       if (!layout.manuallyStopped) {
@@ -584,6 +587,10 @@ ColaLayout.prototype.run = function () {
       }
     }, options.maxSimulationTime);
   }
+
+  adaptor.avoidOverlaps(options.avoidOverlap).handleDisconnected(options.handleDisconnected).start(options.unconstrIter, options.userConstIter, options.allConstIter, undefined, // gridSnapIterations = 0
+  undefined, // keepRunning = true
+  options.centerGraph);
 
   return this; // chaining
 };

--- a/src/cola.js
+++ b/src/cola.js
@@ -180,19 +180,25 @@ ColaLayout.prototype.run = function(){
         return ret;
       };
 
-      if( options.animate ){
-        let frame = function(){
-          if( multitick() ){ return; }
+      // if not animated, run in a timeout so the
+      // options.maxSimulationTime timeout has a chance to interrupt
+      let frame = function(){
+        if( multitick() ){ return; }
 
+        if (options.animate) {
           raf( frame );
-        };
-
-        raf( frame );
-      } else {
-        while( !inftick() ){
-          // keep going...
         }
+        else {
+          setTimeout(() => frame())
+        }
+      };
+      if (options.animate) {
+        raf( frame );
       }
+      else {
+        setTimeout(() => frame())
+      }
+
     },
 
     on: nop, // dummy; not needed

--- a/src/cola.js
+++ b/src/cola.js
@@ -461,6 +461,14 @@ ColaLayout.prototype.run = function(){
 
   layout.trigger({ type: 'layoutstart', layout: layout });
 
+  if( !options.infinite ){
+    setTimeout(function(){
+      if( !layout.manuallyStopped ){
+        adaptor.stop();
+      }
+    }, options.maxSimulationTime);
+  }
+
   adaptor
     .avoidOverlaps( options.avoidOverlap )
     .handleDisconnected( options.handleDisconnected )
@@ -473,14 +481,6 @@ ColaLayout.prototype.run = function(){
       options.centerGraph
     )
   ;
-
-  if( !options.infinite ){
-    setTimeout(function(){
-      if( !layout.manuallyStopped ){
-        adaptor.stop();
-      }
-    }, options.maxSimulationTime);
-  }
 
   return this; // chaining
 };


### PR DESCRIPTION
Register timeout before starting the algorithm
This allows the layout to be stopped in a more timely manner
on large networks.

Obey maxSimulationTime when not animated
If not animated (requestAnimationFrame),
the loop can never be interrupted by the maxSimulationTime timeout.
Solve this by running the layout in a timeout as well.
